### PR TITLE
fix: parse utf8 source null problem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub fn parse(text: &str) -> ParseResult<VecDeque<Line>> {
         }
 
         // Parse source component.
-        if line.chars().nth(idx).unwrap() == ':' {
+        if line.find(':') == Some(idx) {
             let end_idx = find_index(line, ' ', idx).unwrap();
             source = Some(line[idx..end_idx].to_string());
             idx = end_idx + 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub fn parse(text: &str) -> ParseResult<VecDeque<Line>> {
         }
 
         // Parse source component.
-        if line.find(':') == Some(idx) {
+        if line[idx..].find(':') == Some(0) {
             let end_idx = find_index(line, ' ', idx).unwrap();
             source = Some(line[idx..end_idx].to_string());
             idx = end_idx + 1;


### PR DESCRIPTION
fix problem when parse line contains utf8, source field will be null